### PR TITLE
Create `spm12` package

### DIFF
--- a/recipes/spm12/README.md
+++ b/recipes/spm12/README.md
@@ -1,0 +1,31 @@
+# Create the spm12 package
+
+Find more information in the [Standalone SPM](https://www.fil.ion.ucl.ac.uk/spm/docs/installation/standalone/) documentation.
+
+The binaries are available starting from the [Download SPM](https://www.fil.ion.ucl.ac.uk/spm/software/download/) page.
+
+Initial SPM Standalone binary packages used to be built against MATLAB R2010a and depended on the associated MATLAB Runtime 7.13. Unfortunately, that obsolete version of the MATLAB Runtime is not compatible with recent Linux distributions. We had to jump through hoops to run SPM12 on recent Linux machines, running SPM Standalone against MATLAB Runtime 9.7, associated to MATLAB R2019b, hoping for compatibility both with recent operating systems and the obsolete SPM Standalone binary package:
+* [issue to open SPM8 standalone and SPM12 standalone with the latest singularity image](https://github.com/brainvisa/casa-distro/issues/268)
+
+Nowadays, FIL provide multiple versions of the latest release 7771 of SPM12, each for a specific version of the MATLAB Runtime:
+
+| SPM12 Standalone 7771 package  | MATLAB Runtime version |
+| ------------------------------ | ---------------------- |
+| `spm12_r7771_R2010a.zip`       | MATLAB Runtime 7.13    |
+| `spm12_r7771_Linux_R2015b.zip` | MATLAB Runtime 9.0     |
+| `spm12_r7771_Linux_R2016a.zip` | MATLAB Runtime 9.0.1   |
+| `spm12_r7771_Linux_R2016b.zip` | MATLAB Runtime 9.1     |
+| `spm12_r7771_Linux_R2017a.zip` | MATLAB Runtime 9.2     |
+| `spm12_r7771_Linux_R2017b.zip` | MATLAB Runtime 9.3     |
+| `spm12_r7771_Linux_R2018a.zip` | MATLAB Runtime 9.4     |
+| `spm12_r7771_Linux_R2018b.zip` | MATLAB Runtime 9.5     |
+| `spm12_r7771_Linux_R2019a.zip` | MATLAB Runtime 9.6     |
+| `spm12_r7771_Linux_R2019b.zip` | MATLAB Runtime 9.7     |
+| `spm12_r7771_Linux_R2020a.zip` | MATLAB Runtime 9.8     |
+| `spm12_r7771_Linux_R2020b.zip` | MATLAB Runtime 9.9     |
+| `spm12_r7771_Linux_R2021a.zip` | MATLAB Runtime 9.10    |
+| `spm12_r7771_Linux_R2021b.zip` | MATLAB Runtime 9.11    |
+| `spm12_r7771_Linux_R2022a.zip` | MATLAB Runtime 9.12    |
+| `spm12_r7771_Linux_R2022b.zip` | MATLAB Runtime 9.13    |
+
+For now, I'm depending on MATLAB Runtime Version 9.7, but that's obviously not satisfactory.

--- a/recipes/spm12/recipe.yaml
+++ b/recipes/spm12/recipe.yaml
@@ -1,0 +1,55 @@
+package:
+  name: spm12
+  version: 7771
+
+source:
+  #~ url: https://www.fil.ion.ucl.ac.uk/spm/download/restricted/utopia/spm12/spm12_r${{version}}_Linux_R2019b.zip
+  #~ path: /drf/neuro-forge/pool/spm12/spm12_r7771_Linux_R2019b.zip
+  path: /tmp/spm12_r7771_Linux_R2019b.zip
+  sha256: 227271e160f85f460323105db82e4966532c52b7a8be3f6af0ed452a4b5684d9
+
+requirements:
+  run:
+    - matlab-runtime-9.7
+
+build:
+  number: 0
+  script: |
+    mkdir "$PREFIX/bin"
+    
+    cat > "$PREFIX/bin/spm12" <<EOF
+    #!/bin/sh
+    #
+    # https://github.com/spm/spm-docker/blob/main/matlab/singularity.def
+    #
+    export MCR_INHIBIT_CTF_LOCK=1
+    export SPM_HTML_BROWSER=0
+    #
+    # Start a new interactive shell for SPM12
+    #
+    exec "\${CONDA_PREFIX}/spm12/run_spm12.sh" "\${CONDA_PREFIX}/MATLAB/MATLAB_Runtime/v97" \${1+"\$@"}
+    EOF
+    
+    chmod +x "$PREFIX/bin/spm12"
+    
+    mv spm12 "$PREFIX"
+    
+    "\${PREFIX}/spm12/run_spm12.sh" "\${CONDA_PREFIX}/MATLAB/MATLAB_Runtime/v97" quit
+  dynamic_linking:
+    binary_relocation: false
+
+about:
+  homepage: https://www.fil.ion.ucl.ac.uk/spm/software/spm12/
+  license: "GPL-2.0-or-later"
+  summary: |
+    Analysis of brain imaging data sequences
+  description: |
+    The SPM software package has been designed for the analysis of brain
+    imaging data sequences. The sequences can be a series of images from
+    different cohorts, or time-series from the same subject.
+    
+    A standalone SPM is a version of SPM that has been compiled using
+    the MATLAB Compiler so that it does not require the availability
+    of a MATLAB licence.
+  documentation: https://www.fil.ion.ucl.ac.uk/spm/docs/installation/standalone/
+


### PR DESCRIPTION
Find more information in the [Standalone SPM](https://www.fil.ion.ucl.ac.uk/spm/docs/installation/standalone/) documentation.

The binaries are available starting from the [Download SPM](https://www.fil.ion.ucl.ac.uk/spm/software/download/) page.

Initial SPM Standalone binary packages used to be built against MATLAB R2010a and depended on the associated MATLAB Runtime 7.13. Unfortunately, that obsolete version of the MATLAB Runtime is not compatible with recent Linux distributions. We had to jump through hoops to run SPM12 on recent Linux machines, running SPM Standalone against MATLAB Runtime 9.7, associated to MATLAB R2019b, hoping for compatibility both with recent operating systems and the obsolete SPM Standalone binary package:
* [issue to open SPM8 standalone and SPM12 standalone with the latest singularity image](https://github.com/brainvisa/casa-distro/issues/268)

Nowadays, FIL provide multiple versions of the lastest release 7771 of SPM12, each for a specific version of the MATLAB Runtime:

| SPM12 Standalone 7771 package  | MATLAB Runtime version |
| ------------------------------ | ---------------------- |
| `spm12_r7771_R2010a.zip`       | MATLAB Runtime 7.13    |
| `spm12_r7771_Linux_R2015b.zip` | MATLAB Runtime 9.0     |
| `spm12_r7771_Linux_R2016a.zip` | MATLAB Runtime 9.0.1   |
| `spm12_r7771_Linux_R2016b.zip` | MATLAB Runtime 9.1     |
| `spm12_r7771_Linux_R2017a.zip` | MATLAB Runtime 9.2     |
| `spm12_r7771_Linux_R2017b.zip` | MATLAB Runtime 9.3     |
| `spm12_r7771_Linux_R2018a.zip` | MATLAB Runtime 9.4     |
| `spm12_r7771_Linux_R2018b.zip` | MATLAB Runtime 9.5     |
| `spm12_r7771_Linux_R2019a.zip` | MATLAB Runtime 9.6     |
| `spm12_r7771_Linux_R2019b.zip` | MATLAB Runtime 9.7     |
| `spm12_r7771_Linux_R2020a.zip` | MATLAB Runtime 9.8     |
| `spm12_r7771_Linux_R2020b.zip` | MATLAB Runtime 9.9     |
| `spm12_r7771_Linux_R2021a.zip` | MATLAB Runtime 9.10    |
| `spm12_r7771_Linux_R2021b.zip` | MATLAB Runtime 9.11    |
| `spm12_r7771_Linux_R2022a.zip` | MATLAB Runtime 9.12    |
| `spm12_r7771_Linux_R2022b.zip` | MATLAB Runtime 9.13    |

For now, I'm depending on MATLAB Runtime Version 9.7, for consistency with other packages, and to avoid depending on multiple MATLAB Runtime versions.
