### PR TITLE
Fix LD_LIBRARY_PATH for matlab-runtime in SPM12

### DIFF
--- a/recipes/spm12/recipe.yaml
+++ b/recipes/spm12/recipe.yaml
@@ -16,9 +16,10 @@ requirements:
     - matlab-runtime-9.7
 
 build:
-  number: 0
+  number: 1
   script:
     - mkdir $PREFIX/spm12
+    - sed -i 's+  export LD_LIBRARY_PATH;+  LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${CONDA_PREFIX}/lib;\n  export LD_LIBRARY_PATH;+' run_spm12.sh
     - mv run_spm12.sh spm12 spm12.ctf $PREFIX/spm12/
     - $PREFIX/spm12/run_spm12.sh $PREFIX/MATLAB/MATLAB_Runtime/v97 quit
     - mkdir $PREFIX/bin


### PR DESCRIPTION
`spm12` does not work when installed in a minimal Ubuntu system (tested from a container) because some X related libraries are not on the system and not found by Matlab.