### PR TITLE
fixes: jxrlib-dev neuroforge package dependency is mandatory

### DIFF
--- a/recipes/soma-openslide/recipe.yaml
+++ b/recipes/soma-openslide/recipe.yaml
@@ -34,7 +34,7 @@ requirements:
     - xorg-xproto
     - xorg-xextproto
     - openjpeg
-    - jxrlib
+    - jxrlib-dev
     - cairo
     - libpng
     - libtiff


### PR DESCRIPTION
jxrlib-dev neuroforge package dependency is mandatory to support JPEGXR compression in soma-openslide